### PR TITLE
Made BeanMapper a mandatory dependency and upgraded it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,6 @@
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper</artifactId>
             <version>${beanmapper.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	
 	    <spring.version>4.2.6.RELEASE</spring.version>
 
-        <beanmapper.version>0.3.2</beanmapper.version>
+        <beanmapper.version>2.3.1</beanmapper.version>
     </properties>
 
     <distributionManagement>

--- a/src/test/java/nl/_42/beanie/BeanBuilderTest.java
+++ b/src/test/java/nl/_42/beanie/BeanBuilderTest.java
@@ -28,7 +28,7 @@ public class BeanBuilderTest {
     public void setUp() {
         beanBuilder = new BeanBuilder();
         beanBuilder.register(new AnnotationSupportable(SimpleAnnotation.class), new SimplePropertyValueGenerator());
-        beanBuilder.setBeanMapper(new BeanMapperBuilder().build());
+        beanBuilder.setBeanMapper(new BeanMapperBuilder().setApplyStrictMappingConvention(false).build());
 	}
 
 	@Test


### PR DESCRIPTION
Beanie cannot be used without BeanMapper, as the BeanBuilder class has a hard dependency on BeanMapper. 

Therefore, package the currently-latest version of BeanMapper by default (2.3.1).
If the user wants to use an newer (or perhaps older) version of BeanMapper, it can be overriden in the POM of that project.